### PR TITLE
Adapted for multiple certs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,7 +111,7 @@
   cron:
     name: 'renew SSL certificates for {{ letsencrypt_domains[0] }}'
     job: '{{ letsencrypt_install_path }}/{{ letsencrypt_domains[0] }}-renew_certificate.sh'
-    minute: '{{ letsencrypt_cron_renew[0] }}'
+    minute: '{{ 59 | random }}'
     hour: '{{ letsencrypt_cron_renew[1] }}'
     day: '{{ letsencrypt_cron_renew[2] }}'
     weekday: '{{ letsencrypt_cron_renew[3] }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,8 +109,8 @@
 
 - name: Create crontab to renew SSL certificates
   cron:
-    name: 'renew SSL certificates'
-    job: '{{ letsencrypt_install_path }}/renew_certificate.sh'
+    name: 'renew SSL certificates for {{ letsencrypt_domains[0] }}'
+    job: '{{ letsencrypt_install_path }}/{{ letsencrypt_domains[0] }}-renew_certificate.sh'
     minute: '{{ letsencrypt_cron_renew[0] }}'
     hour: '{{ letsencrypt_cron_renew[1] }}'
     day: '{{ letsencrypt_cron_renew[2] }}'


### PR DESCRIPTION
The current one doesn't take into account if you have multiple certs. The cronjob gets overwritten every time your run the role with a new cert. Now one job is created for each cert. I also randomized the starting minute, so we don't hit a rate-limiter for some reason....