### PR TITLE
Allow specifying more than one service to reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Below is a list of default values along with a description of what they do.
 # both the root domain and the www sub-domain.
 letsencrypt_domains: []
 
-# Which web server services need to get restarted at the end of the run?
-letsencrypt_restart_services: ['nginx']
+# Which web server services need to get reloaded at the end of the run?
+letsencrypt_reload_services: ['nginx']
 
 # Installation paths.
 letsencrypt_install_path: '/usr/local/acme-tiny'

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Below is a list of default values along with a description of what they do.
 # both the root domain and the www sub-domain.
 letsencrypt_domains: []
 
-# Which web server service name needs to get restarted at the end of the run?
-letsencrypt_restart_service_name: 'nginx'
+# Which web server services need to get restarted at the end of the run?
+letsencrypt_restart_services: ['nginx']
 
 # Installation paths.
 letsencrypt_install_path: '/usr/local/acme-tiny'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 letsencrypt_domains: []
 
 letsencrypt_restart_service_name: 'nginx'
+letsencrypt_restart_services:
+    - "{{ letsencrypt_restart_service_name }}"
 
 letsencrypt_install_path: '/usr/local/acme-tiny'
 letsencrypt_challenge_path: '/usr/share/nginx/challenges/.well-known/acme-challenge'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 letsencrypt_domains: []
 
 letsencrypt_restart_service_name: 'nginx'
-letsencrypt_restart_services:
+letsencrypt_reload_services:
     - "{{ letsencrypt_restart_service_name }}"
 
 letsencrypt_install_path: '/usr/local/acme-tiny'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Restart service (nginx, apache, haproxy, etc.)
+- name: Reload service (nginx, apache, haproxy, etc.)
   service:
     name: '{{ item }}'
-    state: 'restarted'
-  with_items: '{{ letsencrypt_restart_services }}'
+    state: 'reloaded'
+  with_items: '{{ letsencrypt_reload_services }}'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,6 @@
 
 - name: Restart service (nginx, apache, haproxy, etc.)
   service:
-    name: '{{ letsencrypt_restart_service_name }}'
+    name: '{{ item }}'
     state: 'restarted'
+  with_items: '{{ letsencrypt_restart_services }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,7 +97,7 @@
   shell: 'cat {{ letsencrypt_valid_certificate_path }} {{ letsencrypt_install_path }}/intermediate.crt > {{ letsencrypt_chained_pem_path }}'
   when: (letsencrypt_register_output | changed) and (letsencrypt_register_output.stderr.endswith('Certificate signed!'))
   notify:
-    - Restart service (nginx, apache, haproxy, etc.)
+    - Reload service (nginx, apache, haproxy, etc.)
 
 - name: Copy renew_certificate to the installation path
   template:

--- a/templates/usr/local/acme-tiny/renew_certificate.sh.j2
+++ b/templates/usr/local/acme-tiny/renew_certificate.sh.j2
@@ -18,4 +18,6 @@ wget {{ letsencrypt_intermediate_url }} -O "${INTERMEDIATE_PATH}"
 cat "${TEMP_CERT_PATH}" "${INTERMEDIATE_PATH}" > {{ letsencrypt_chained_pem_path }}
 
 # Restart service to pickup the certificate change.
-sudo service {{ letsencrypt_restart_service_name }} restart
+{% for service in letsencrypt_restart_services %}
+sudo service {{ service }} restart
+{% endfor %}

--- a/templates/usr/local/acme-tiny/renew_certificate.sh.j2
+++ b/templates/usr/local/acme-tiny/renew_certificate.sh.j2
@@ -17,7 +17,7 @@ INTERMEDIATE_PATH="{{ letsencrypt_install_path }}/intermediate.crt"
 wget {{ letsencrypt_intermediate_url }} -O "${INTERMEDIATE_PATH}"
 cat "${TEMP_CERT_PATH}" "${INTERMEDIATE_PATH}" > {{ letsencrypt_chained_pem_path }}
 
-# Restart service to pickup the certificate change.
-{% for service in letsencrypt_restart_services %}
-sudo service {{ service }} restart
+# Reload services to pickup the certificate change.
+{% for service in letsencrypt_reload_services %}
+sudo service {{ service }} reload
 {% endfor %}


### PR DESCRIPTION
This pull request implements two changes (in two separate commits):

- 91ecf4f: Allow specifying more than one service to be restarted. This brings a new default variable `letsencrypt_restart_services` which should be an array of service names.
- c8933e5: Reload services instead of restarting them (I think this is more appropriate for most services including nginx, postfix, dovecot). This changes the variable name to `letsencrypt_reload_services`

Both changes are backward compatible with the existing `letsencrypt_restart_service_name` variable.